### PR TITLE
Fix direct linking in the cloudfront distribution

### DIFF
--- a/tf/modules/s3-static-website/cf.tf
+++ b/tf/modules/s3-static-website/cf.tf
@@ -41,6 +41,13 @@ resource "aws_cloudfront_distribution" "dist" {
     Environment = "${var.environment}"
   }
 
+  custom_error_response {
+    error_caching_min_ttl = 300
+    error_code            = 404
+    response_code         = 200
+    response_page_path    = "/index.html"
+  }
+
   viewer_certificate {
     acm_certificate_arn = aws_acm_certificate_validation.cert.certificate_arn
     ssl_support_method = "sni-only"

--- a/tf/modules/s3-static-website/cf.tf
+++ b/tf/modules/s3-static-website/cf.tf
@@ -31,7 +31,8 @@ resource "aws_cloudfront_distribution" "dist" {
         forward = "none"
       }
     }
-    viewer_protocol_policy = "allow-all"
+    viewer_protocol_policy = "redirect-to-https"
+
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 86400

--- a/tf/modules/s3-static-website/cf.tf
+++ b/tf/modules/s3-static-website/cf.tf
@@ -35,6 +35,7 @@ resource "aws_cloudfront_distribution" "dist" {
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 86400
+    compress               = true
   }
 
   tags = {


### PR DESCRIPTION
Also enable compression because the client has to download the wasm file and load it before it does anything.